### PR TITLE
Add hall selection for Cinebuzz screenings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎬 Cinébuzz
 
-**Cinébuzz** est une plateforme web de réservation de billets de cinéma, conçue en Python. Elle permet aux utilisateurs de consulter les films à l'affiche, réserver en ligne, voir les bandes-annonces, et découvrir les snacks disponibles dans leur salle préférée.
+**Cinébuzz** est une plateforme web de réservation de billets de cinéma, conçue en Python. Elle permet aux utilisateurs de consulter les films à l'affiche, réserver en ligne, voir les bandes-annonces, et découvrir les snacks disponibles dans leur salle préférée. Chaque film est proposé dans deux salles&nbsp;: **Utex** et **Shopping Mall**, avec trois séances fixes (10h, 15h et 20h).
 
 ---
 

--- a/db_migration_add_salle.py
+++ b/db_migration_add_salle.py
@@ -1,0 +1,15 @@
+import sqlite3
+
+def add_column(db, table, column_sql):
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    try:
+        cur.execute(f"ALTER TABLE {table} ADD COLUMN {column_sql}")
+        print(f"✅ Colonne '{column_sql.split()[0]}' ajoutée à {table}.")
+    except sqlite3.OperationalError as e:
+        print(f"ℹ️ {table}: {e}")
+    conn.commit()
+    conn.close()
+
+add_column('cinebuzz.db', 'films', "salle TEXT DEFAULT 'Utex'")
+add_column('reservations.db', 'reservations', "salle TEXT DEFAULT 'Utex'")

--- a/templates/accueil.html
+++ b/templates/accueil.html
@@ -12,7 +12,7 @@
                     <img src="https://image.tmdb.org/t/p/w780{{ film.affiche }}" alt="{{ film.titre }}">
                     <div class="slide-caption">
                         <h2>{{ film.titre }}</h2>
-                        <p>{{ film.version }} – {{ film.horaires }}</p>
+                        <p>{{ film.version }} – {{ film.salle }} – {{ film.horaires }}</p>
                         <a href="{{ url_for('detail_film', tmdb_id=film.tmdb_id) }}" class="btn">Voir le détail</a>
                     </div>
                 </div>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -41,6 +41,12 @@
             <option value="VOSTFR">VOSTFR</option>
         </select>
 
+        <label for="salle">Salle :</label>
+        <select name="salle">
+            <option value="Utex">Utex</option>
+            <option value="Shopping Mall">Shopping Mall</option>
+        </select>
+
         <label for="tmdb_id">ID TMDb :</label>
         <input type="text" name="tmdb_id" id="tmdb_id" readonly required>
 

--- a/templates/admin_reservations.html
+++ b/templates/admin_reservations.html
@@ -102,6 +102,7 @@
             <th>Téléphone</th>
             <th>Film</th>
             <th>Date</th>
+            <th>Salle</th>
             <th>Horaire</th>
             <th>WhatsApp</th>
         </tr>
@@ -113,9 +114,10 @@
             <td>{{ r[3] }}</td>
             <td>{{ r[4] }}</td>
             <td>{{ r[5] }}</td>
+            <td>{{ r[6] }}</td>
             <td>
                 <a class="wa-button"
-                   href="https://wa.me/243845040599?text=Bonjour%20{{ r[0]|urlencode }}%2C%20vous%20avez%20réservé%20pour%20le%20film%20{{ r[3]|urlencode }}%20le%20{{ r[4] }}%20à%20{{ r[5] }}.%20Merci%20de%20confirmer."
+                   href="https://wa.me/243845040599?text=Bonjour%20{{ r[0]|urlencode }}%2C%20vous%20avez%20réservé%20pour%20le%20film%20{{ r[3]|urlencode }}%20le%20{{ r[4] }}%20en%20salle%20{{ r[5] }}%20à%20{{ r[6] }}.%20Merci%20de%20confirmer."
                    target="_blank">📲 WhatsApp</a>
             </td>
         </tr>

--- a/templates/ajouter_film.html
+++ b/templates/ajouter_film.html
@@ -25,6 +25,10 @@
                         <option value="VF">VF</option>
                         <option value="VOSTFR">VOSTFR</option>
                     </select>
+                    <select name="salle" required>
+                        <option value="Utex">Utex</option>
+                        <option value="Shopping Mall">Shopping Mall</option>
+                    </select>
                     <button type="submit">🎟️ Ajouter {{ film.title }}</button>
                 </form>
             </li>
@@ -48,6 +52,10 @@
     <select name="version" required>
         <option value="VF">VF</option>
         <option value="VOSTFR">VOSTFR</option>
+    </select><br>
+    <select name="salle" required>
+        <option value="Utex">Utex</option>
+        <option value="Shopping Mall">Shopping Mall</option>
     </select><br>
     <button type="submit">Ajouter</button>
 </form>

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -87,9 +87,9 @@
     {% if projections %}
         <label for="choix-seance"><strong>Choisissez une séance :</strong></label><br>
         <select id="choix-seance">
-            {% for date, horaires in projections %}
+            {% for date, horaires, salle in projections %}
                 {% for horaire in horaires.split(',') %}
-                    <option value="{{ date }}|{{ horaire.strip() }}">{{ date }} à {{ horaire.strip() }}</option>
+                    <option value="{{ date }}|{{ horaire.strip() }}|{{ salle }}">{{ date }} {{ salle }} {{ horaire.strip() }}</option>
                 {% endfor %}
             {% endfor %}
         </select>

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
             {% for film in films %}
             <div class="slide" style="background-image: url('{{ film.affiche }}');">
                 <h2>{{ film.titre }}</h2>
-                <p><strong>Horaires :</strong> {{ film.horaires }}</p>
+                <p><strong>Salle :</strong> {{ film.salle }} | <strong>Horaires :</strong> {{ film.horaires }}</p>
                 <p><strong>Version :</strong> {{ film.version }}</p>
             </div>
             {% endfor %}

--- a/templates/programme.html
+++ b/templates/programme.html
@@ -55,7 +55,7 @@
                     <div class="film-info">
                         <h3><a href="{{ url_for('detail_film', tmdb_id=film.tmdb_id) }}">{{ film.titre }}</a></h3>
 
-                        <p><strong>Horaires :</strong> {{ film.horaires }}</p>
+                        <p><strong>Salle :</strong> {{ film.salle }} | <strong>Horaires :</strong> {{ film.horaires }}</p>
                         <p><strong>Version :</strong> {{ film.version }}</p>
                     </div>
                 </div>

--- a/templates/reserver.html
+++ b/templates/reserver.html
@@ -31,14 +31,21 @@
 
         <label for="date_projection">Date :</label>
         <select name="date_projection" required>
-            {% for date, horaires in projections %}
+            {% for date, horaires, salle in projections %}
                 <option value="{{ date }}">{{ date }}</option>
+            {% endfor %}
+        </select>
+
+        <label for="salle">Salle :</label>
+        <select name="salle" required>
+            {% for date, horaires, salle in projections %}
+                <option value="{{ salle }}">{{ salle }}</option>
             {% endfor %}
         </select>
 
         <label for="horaire">Horaire :</label>
         <select name="horaire" required>
-            {% for date, horaires in projections %}
+            {% for date, horaires, salle in projections %}
                 {% for h in horaires.split(',') %}
                     <option value="{{ h.strip() }}">{{ h.strip() }}</option>
                 {% endfor %}


### PR DESCRIPTION
## Summary
- support hall choice when adding films and making reservations
- include hall information throughout templates
- update CSV export and reservations admin view
- document new halls in README
- provide database migration script

## Testing
- `python3 test.py`
- `python3 tmdb_test.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846e133a6948328aedc4fdc372289c1